### PR TITLE
Support for master-worker mode (haproxy 1.8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:1.7.5
+FROM haproxy:1.8.3
 
 MAINTAINER Jaime Soriano Pastor <jsoriano@tuenti.com>
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.8.3
+FROM golang:1.9.2
 
 RUN apt-get update \
 	&& apt-get install -y libnetfilter-queue-dev iptables \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION := 1.3.3
-DOCKER_TAG := haproxy-docker-wrapper:$(VERSION)_1.7.5
+DOCKER_TAG := haproxy-docker-wrapper:$(VERSION)_1.8.3
 PACKAGE := github.com/tuenti/haproxy-docker-wrapper
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 

--- a/controller.go
+++ b/controller.go
@@ -1,4 +1,4 @@
-// Copyright © 2016 Tuenti Technologies S.L.
+// Copyright © 2018 Tuenti Technologies S.L.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,13 +23,13 @@ import (
 
 type Controller struct {
 	address string
-	haproxy *HaproxyServer
+	haproxy HaproxyServer
 
 	done     bool
 	listener net.Listener
 }
 
-func NewController(address string, haproxy *HaproxyServer) *Controller {
+func NewController(address string, haproxy HaproxyServer) *Controller {
 	return &Controller{
 		address: address,
 		haproxy: haproxy,

--- a/haproxy.go
+++ b/haproxy.go
@@ -1,4 +1,4 @@
-// Copyright © 2016 Tuenti Technologies S.L.
+// Copyright © 2018 Tuenti Technologies S.L.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,15 +15,7 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
-	"log"
-	"os"
-	"os/exec"
-	"strconv"
-	"sync"
-	"syscall"
-	"time"
 )
 
 const (
@@ -32,188 +24,28 @@ const (
 	StateWaiting
 )
 
-type HaproxyServer struct {
-	sync.Mutex
-	reloading sync.Mutex
-	state     int
-
-	path, pidFile, configFile string
+type HaproxyServer interface {
+	Start() error
+	Stop() error
+	Reload() error
+	IsRunning() bool
 }
 
-func NewHaproxyServer(path, pidFile, configFile string) *HaproxyServer {
-	return &HaproxyServer{
-		path:       path,
-		pidFile:    pidFile,
-		configFile: configFile,
+func NewHaproxyServer(path, pidFile, configFile, mode string) (HaproxyServer, error) {
+	switch mode {
+	case "daemon":
+		return &HaproxyServerDaemon{
+			path:       path,
+			pidFile:    pidFile,
+			configFile: configFile,
+		}, nil
+	case "master-worker":
+		return &HaproxyServerMasterWorker{
+			path:       path,
+			pidFile:    pidFile,
+			configFile: configFile,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown haproxy mode: %s", mode)
 	}
-}
-
-func (s *HaproxyServer) buildCommand(reload bool) *exec.Cmd {
-	args := []string{"-f", s.configFile, "-p", s.pidFile}
-
-	if reload && s.IsRunning() {
-		pids, _ := s.Pids()
-		pidArgs := make([]string, len(pids))
-		for i := range pids {
-			pidArgs[i] = strconv.Itoa(pids[i])
-		}
-		args = append(args, "-sf")
-		args = append(args, pidArgs...)
-	}
-	cmd := exec.Command(s.path, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stdout
-	return cmd
-}
-
-func (s *HaproxyServer) Pids() ([]int, error) {
-	var pids []int
-
-	file, err := os.Open(s.pidFile)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't open pidfile %s", s.pidFile)
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	scanner.Split(bufio.ScanWords)
-	for scanner.Scan() {
-		text := scanner.Text()
-		pid, err := strconv.Atoi(text)
-		if err == nil {
-			pids = append(pids, pid)
-		}
-	}
-	return pids, nil
-}
-
-func (s *HaproxyServer) Pid() int {
-	pids, err := s.Pids()
-	if err != nil {
-		fmt.Println(err)
-		return 0
-	}
-	if len(pids) == 0 {
-		return 0
-	}
-	return pids[0]
-}
-
-func (s *HaproxyServer) Signal(signal os.Signal) error {
-	p, err := os.FindProcess(s.Pid())
-	if err != nil {
-		return err
-	}
-	return p.Signal(signal)
-}
-
-func (s *HaproxyServer) IsRunning() bool {
-	err := s.Signal(syscall.Signal(0))
-	return err == nil
-}
-
-func (s *HaproxyServer) Kill() error {
-	p, err := os.FindProcess(s.Pid())
-	if err != nil {
-		return err
-	}
-	return p.Kill()
-}
-
-func (s *HaproxyServer) Start() error {
-	if s.IsRunning() {
-		return fmt.Errorf("Server already started")
-	}
-	cmd := s.buildCommand(false)
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	return cmd.Wait()
-}
-
-func (s *HaproxyServer) Stop() error {
-	if !s.IsRunning() {
-		return fmt.Errorf("Server not started")
-	}
-	err := s.Kill()
-	if err != nil {
-		return fmt.Errorf("Couldn't kill process: %v", err)
-	}
-	return nil
-}
-
-func (s *HaproxyServer) requestReload() bool {
-	s.Lock()
-	defer s.Unlock()
-	switch s.state {
-	case StateIdle:
-		s.state = StateReloading
-	case StateReloading:
-		s.state = StateWaiting
-	case StateWaiting:
-		return false
-	}
-	return true
-}
-
-func (s *HaproxyServer) finishReload() {
-	s.Lock()
-	defer s.Unlock()
-	switch s.state {
-	case StateIdle:
-	case StateReloading:
-		s.state = StateIdle
-	case StateWaiting:
-		s.state = StateReloading
-	}
-}
-
-func (s *HaproxyServer) Reload() error {
-	if !s.requestReload() {
-		return nil
-	}
-	defer s.finishReload()
-
-	s.reloading.Lock()
-	defer s.reloading.Unlock()
-
-	currentPids, _ := s.Pids()
-
-	start := time.Now()
-	err := func() error {
-		cmd := s.buildCommand(s.IsRunning())
-
-		netQueue.Capture()
-		defer netQueue.Release()
-
-		if err := cmd.Start(); err != nil {
-			return err
-		}
-		if err := cmd.Wait(); err != nil {
-			return fmt.Errorf("Haproxy couldn't reload configuration: %v", err)
-		}
-		return nil
-	}()
-	if err != nil {
-		return err
-	}
-	log.Printf("Reload took %s", time.Since(start))
-
-	for _, pid := range currentPids {
-		p, err := os.FindProcess(pid)
-		if err != nil {
-			// This shouldn't happen in UNIX systems
-			log.Printf("os.FindProcess(%d) failed, this shouldn't happen: %v\n", pid, err)
-			continue
-		}
-		go func() {
-			if _, err := p.Wait(); err != nil {
-				log.Printf("Cannot wait for old haproxy: %v\n", err)
-			}
-			log.Printf("Old process with pid %d finished\n", p.Pid)
-		}()
-	}
-
-	log.Println("Haproxy reloaded with pid", s.Pid())
-	return nil
 }

--- a/haproxy_daemon.go
+++ b/haproxy_daemon.go
@@ -1,0 +1,223 @@
+// Copyright © 2018 Tuenti Technologies S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+)
+
+var nfQueueNumber uint
+var netQueueIps string
+
+func init() {
+	flag.UintVar(&nfQueueNumber, "nf-queue-number", 0, "Netfilter queue number to retain connections during reload in daemon mode")
+	flag.StringVar(&netQueueIps, "net-queue-ips", "", "Comma-separated list of IPs where connections will be retained during reload in daemon mode")
+}
+
+type HaproxyServerDaemon struct {
+	sync.Mutex
+	reloading sync.Mutex
+	state     int
+	netQueue  NetQueue
+
+	path, pidFile, configFile string
+}
+
+func (s *HaproxyServerDaemon) buildCommand(reload bool) *exec.Cmd {
+	args := []string{"-D", "-f", s.configFile, "-p", s.pidFile}
+
+	if reload && s.IsRunning() {
+		pids, _ := s.Pids()
+		pidArgs := make([]string, len(pids))
+		for i := range pids {
+			pidArgs[i] = strconv.Itoa(pids[i])
+		}
+		args = append(args, "-sf")
+		args = append(args, pidArgs...)
+	}
+	cmd := exec.Command(s.path, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
+	return cmd
+}
+
+func (s *HaproxyServerDaemon) Pids() ([]int, error) {
+	var pids []int
+
+	file, err := os.Open(s.pidFile)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't open pidfile %s", s.pidFile)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Split(bufio.ScanWords)
+	for scanner.Scan() {
+		text := scanner.Text()
+		pid, err := strconv.Atoi(text)
+		if err == nil {
+			pids = append(pids, pid)
+		}
+	}
+	return pids, nil
+}
+
+func (s *HaproxyServerDaemon) Pid() int {
+	pids, err := s.Pids()
+	if err != nil {
+		fmt.Println(err)
+		return 0
+	}
+	if len(pids) == 0 {
+		return 0
+	}
+	return pids[0]
+}
+
+func (s *HaproxyServerDaemon) Signal(signal os.Signal) error {
+	p, err := os.FindProcess(s.Pid())
+	if err != nil {
+		return err
+	}
+	return p.Signal(signal)
+}
+
+func (s *HaproxyServerDaemon) IsRunning() bool {
+	err := s.Signal(syscall.Signal(0))
+	return err == nil
+}
+
+func (s *HaproxyServerDaemon) Kill() error {
+	p, err := os.FindProcess(s.Pid())
+	if err != nil {
+		return err
+	}
+	return p.Kill()
+}
+
+func (s *HaproxyServerDaemon) Start() error {
+	if s.IsRunning() {
+		return fmt.Errorf("Server already started")
+	}
+
+	ips, err := ipArgs(netQueueIps)
+	if err != nil {
+		log.Fatalf("Expected comma-separated list of IPs: %v", err)
+	}
+	s.netQueue = NewNetQueue(nfQueueNumber, ips)
+
+	cmd := s.buildCommand(false)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return cmd.Wait()
+}
+
+func (s *HaproxyServerDaemon) Stop() error {
+	if !s.IsRunning() {
+		return fmt.Errorf("Server not started")
+	}
+	err := s.Kill()
+	if err != nil {
+		return fmt.Errorf("Couldn't kill process: %v", err)
+	}
+	s.netQueue.Stop()
+	return nil
+}
+
+func (s *HaproxyServerDaemon) requestReload() bool {
+	s.Lock()
+	defer s.Unlock()
+	switch s.state {
+	case StateIdle:
+		s.state = StateReloading
+	case StateReloading:
+		s.state = StateWaiting
+	case StateWaiting:
+		return false
+	}
+	return true
+}
+
+func (s *HaproxyServerDaemon) finishReload() {
+	s.Lock()
+	defer s.Unlock()
+	switch s.state {
+	case StateIdle:
+	case StateReloading:
+		s.state = StateIdle
+	case StateWaiting:
+		s.state = StateReloading
+	}
+}
+
+func (s *HaproxyServerDaemon) Reload() error {
+	if !s.requestReload() {
+		return nil
+	}
+	defer s.finishReload()
+
+	s.reloading.Lock()
+	defer s.reloading.Unlock()
+
+	currentPids, _ := s.Pids()
+
+	start := time.Now()
+	err := func() error {
+		cmd := s.buildCommand(s.IsRunning())
+
+		netQueue.Capture()
+		defer netQueue.Release()
+
+		if err := cmd.Start(); err != nil {
+			return err
+		}
+		if err := cmd.Wait(); err != nil {
+			return fmt.Errorf("Haproxy couldn't reload configuration: %v", err)
+		}
+		return nil
+	}()
+	if err != nil {
+		return err
+	}
+	log.Printf("Reload took %s", time.Since(start))
+
+	for _, pid := range currentPids {
+		p, err := os.FindProcess(pid)
+		if err != nil {
+			// This shouldn't happen in UNIX systems
+			log.Printf("os.FindProcess(%d) failed, this shouldn't happen: %v\n", pid, err)
+			continue
+		}
+		go func() {
+			if _, err := p.Wait(); err != nil {
+				log.Printf("Cannot wait for old haproxy: %v\n", err)
+			}
+			log.Printf("Old process with pid %d finished\n", p.Pid)
+		}()
+	}
+
+	log.Println("Haproxy reloaded with pid", s.Pid())
+	return nil
+}

--- a/haproxy_master_worker.go
+++ b/haproxy_master_worker.go
@@ -1,0 +1,82 @@
+// Copyright © 2018 Tuenti Technologies S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+type HaproxyServerMasterWorker struct {
+	command *exec.Cmd
+
+	path, pidFile, configFile string
+}
+
+func (s *HaproxyServerMasterWorker) IsRunning() bool {
+	if s.command == nil || s.command.Process == nil {
+		return false
+	}
+	err := s.command.Process.Signal(syscall.Signal(0))
+	return err == nil
+}
+
+func (s *HaproxyServerMasterWorker) Reload() error {
+	if !s.IsRunning() {
+		return s.Start()
+	}
+	err := s.command.Process.Signal(syscall.SIGUSR2)
+	if err != nil {
+		return fmt.Errorf("couldn't kill process: %v", err)
+	}
+	return nil
+}
+
+func (s *HaproxyServerMasterWorker) Start() error {
+	if s.IsRunning() {
+		return fmt.Errorf("server already started")
+	}
+	args := []string{"-W", "-f", s.configFile, "-p", s.pidFile}
+	s.command = exec.Command(s.path, args...)
+	s.command.Stdout = os.Stdout
+	s.command.Stderr = os.Stdout
+	if err := s.command.Start(); err != nil {
+		return err
+	}
+
+	go func() {
+		err := s.command.Wait()
+		if err != nil {
+			log.Printf("Haproxy finished with error: %v", err)
+		} else {
+			log.Println("Haproxy finished")
+		}
+	}()
+	return nil
+}
+
+func (s *HaproxyServerMasterWorker) Stop() error {
+	if !s.IsRunning() {
+		return fmt.Errorf("server is not running")
+	}
+	err := s.command.Process.Kill()
+	if err != nil {
+		return fmt.Errorf("couldn't kill server")
+	}
+	return nil
+}


### PR DESCRIPTION
Adds a new flag to handle different haproxy running modes, and adds support for an additional mode, so we'd have now two modes:
* daemon: for haproxy running in daemon mode, and optionally using netfilter queues to delay packets on reloads so no connections are lost, this is the mode we used before.
* master-worker: Intended mostly for haproxy 1.8, running in non-daemon master-worker mode, without hacks for avoid losing connections as [in principle they are not needed anymore](https://www.haproxy.com/blog/whats-new-haproxy-1-8/). In master-worker mode, haproxy can be run non-daemonized with production configuration, and can be reloaded with SIGUSR2 instead with a take-over process, so code handling it is quite simpler.