### PR TITLE
Add a config validation HTTP endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,8 @@ func main() {
 	done := make(chan os.Signal)
 	signal.Notify(done, syscall.SIGTERM, syscall.SIGINT)
 
-	controller := NewController(controlAddress, haproxy)
+	validator := NewHaproxyDashC(haproxyPath, haproxyConfigFile)
+	controller := NewController(controlAddress, haproxy, validator)
 
 	go func() {
 		for {


### PR DESCRIPTION
This endpoint uses haproxy -c to validate haproxy's configuration. This enables the following pattern:

* Change config on disk
* Call validation endpoint to validate config.
* If validation fails, revert changes on disk.
* If validation succeeds, reload haproxy.

For the time being I've had the validator load the same config base the live haproxy process uses. This works fine for my needs, but I could imagine others wanting to point the validator at some staging directory. That would support a more resilient pattern like:

* Change config in staging directory
* Call validation endpoint to validate staging config
* If validation fails, delete staging config
* If validation succeeds, move staging config over live config and reload haproxy