### PR TITLE
Run haproxy 1.8.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:1.8.4
+FROM haproxy:1.8.14
 
 MAINTAINER Jaime Soriano Pastor <jsoriano@tuenti.com>
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION := 2.0.0
-HAPROXY_VERSION := 1.8.4
+HAPROXY_VERSION := 1.8.14
 DOCKER_REPOSITORY := tuenti
 DOCKER_TAG := ${DOCKER_REPOSITORY}/haproxy-docker-wrapper:$(VERSION)_$(HAPROXY_VERSION)
 PACKAGE := github.com/tuenti/haproxy-docker-wrapper


### PR DESCRIPTION
http://git.haproxy.org/?p=haproxy-1.8.git;a=commitdiff;h=71b97fc

This build contains in particular a fix for the above bug, which can cause haproxy to leak processes when running in master/worker mode with more than one thread.